### PR TITLE
Version Check Updates

### DIFF
--- a/loganalyzer.py
+++ b/loganalyzer.py
@@ -163,6 +163,9 @@ def checkOldVersion(lines):
     elif versionString.startswith('22.0.2-26'):
         return [1, "Beta OBS Version",
                 """You are running a beta build of OBS Studio."""]
+    elif versionString.startswith('23.0.0-rc'):
+        return [1, "Release Candidate", 
+        """You are running a release candidate version of OBS Studio."""]
     elif parse_version(versionString) < parse_version(CURRENT_VERSION):
         return [2, "Old Version",
                 """You are not running the latest version of OBS Studio. Please update by downloading the latest installer from the <a href="https://obsproject.com/download">downloads page</a> and running it."""]

--- a/loganalyzer.py
+++ b/loganalyzer.py
@@ -159,7 +159,7 @@ def checkOldVersion(lines):
         return [2, "Broken Auto-Update",
                 """You are not running the latest version of OBS Studio. Automatic updates in version 21.1.0 are broken due to a bug. <br>Please update by downloading the latest installer from the <a href="https://obsproject.com/download">downloads page</a> and running it."""]
     elif versionString.startswith('22.0.2-26'):
-        return [2, "Beta OBS Version",
+        return [1, "Beta OBS Version",
                 """You are running a beta build of OBS Studio."""]
     elif parse_version(versionString) < parse_version(CURRENT_VERSION):
         return [2, "Old Version",

--- a/loganalyzer.py
+++ b/loganalyzer.py
@@ -153,6 +153,8 @@ def checkOldVersion(lines):
     versionLines = search('OBS', lines)
     if versionLines[0].split()[0] == 'OBS':
         versionString = versionLines[0].split()[1]
+    elif versionLines[0].split()[2] == 'OBS':
+        versionString = versionLines[0].split()[3]
     else:
         versionString = versionLines[0].split()[2]
     if parse_version(versionString) == parse_version('21.1.0'):


### PR DESCRIPTION
This PR adds and amends the following:

- Fixes version detection on Linux
  - Logs from Linux versions of OBS were showing as "old version" and the check was returning "OBS" on those builds. This fix checks that "OBS" is not being detected on the second string either, and uses the correct string if it is.
- Downgrades the "Beta version" alert from Warning to Info
  - This is mostly for future-proofing at this point, since betas aren't active, but they're not really worth being a "warning" imo.
- Add release candidate check.
  - Add an info alert for RC builds of OBS Studio 23.0