### PR TITLE
Update current version + x264 preset change

### DIFF
--- a/loganalyzer.py
+++ b/loganalyzer.py
@@ -305,7 +305,7 @@ def checkPreset(lines):
             sensiblePreset = False
 
     if ((len(encoderLines) > 0) and (not sensiblePreset)):
-        return [2, "Wrong Preset",
+        return [1, "Non-Default x264 Preset",
                 "A slower x264 preset than 'veryfast' is in use. It is recommended to leave this value on veryfast, as there are significant diminishing returns to setting it lower. It can also result in very poor gaming performance on the system if you're not using a 2 PC setup."]
 
 

--- a/loganalyzer.py
+++ b/loganalyzer.py
@@ -17,7 +17,7 @@ RESET = "\033[0;0m"
 BOLD = "\033[;1m"
 REVERSE = "\033[;7m"
 
-CURRENT_VERSION = '22.0.2'
+CURRENT_VERSION = '23.0.0'
 
 
 # error levels:


### PR DESCRIPTION
This PR includes the following:

- Update variable CURRENT_VERSION to 23.0.0.
- Changes the "Wrong Preset" warning.
  - "Wrong Preset" isn't entirely accurate, and it's also not warning worthy. The analyzer now reports "non-default x264 preset" with an info level.