### PR TITLE
rename 'Monitor Capture' -> 'Display Capture' in output

### DIFF
--- a/loganalyzer.py
+++ b/loganalyzer.py
@@ -547,7 +547,7 @@ def checkSources(lower, higher, lines):
     if (len(monitor) > 0 and len(game) > 0):
         res = []
         res.append([2, "Capture Interference",
-                    "Monitor and Game Capture Sources interfere with each other. Never put them in the same scene"])
+                    "Display and Game Capture Sources interfere with each other. Never put them in the same scene"])
     if (len(game) > 1):
         if (res is None):
             res = []


### PR DESCRIPTION
...because "Display Capture" is the terminology users see in the UI and
most other places this feature is referenced.